### PR TITLE
feat 03 - add room for data consistency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.serialization) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -48,6 +49,8 @@ dependencies {
     implementation(libs.kotlinx.coroutines.test)
     implementation(libs.androidx.paging.compose)
     implementation(libs.androidx.paging.runtime)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.koin.test)
@@ -62,4 +65,5 @@ dependencies {
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.mockk)
     androidTestImplementation(libs.mockk.agent)
+    ksp(libs.androidx.room.compiler)
 }

--- a/data/src/main/java/com/jperez/lydia/data/database/AppDatabase.kt
+++ b/data/src/main/java/com/jperez/lydia/data/database/AppDatabase.kt
@@ -1,0 +1,12 @@
+package com.jperez.lydia.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.jperez.lydia.data.model.entity.ContactEntity
+import com.jperez.lydia.data.model.entity.PaginationInfoEntity
+
+@Database(entities = [PaginationInfoEntity::class, ContactEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun paginationInfoDao(): PaginationInfoDao
+    abstract fun contactDao(): ContactDao
+}

--- a/data/src/main/java/com/jperez/lydia/data/database/ContactDao.kt
+++ b/data/src/main/java/com/jperez/lydia/data/database/ContactDao.kt
@@ -1,0 +1,27 @@
+package com.jperez.lydia.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.jperez.lydia.data.model.entity.ContactEntity
+
+@Dao
+interface ContactDao {
+
+    /**
+     * Retrieves a list of ContactEntity objects based on the provided pagination info key.
+     *
+     * @param paginationInfoKey The key used to filter the contacts based on pagination information.
+     * @return A list of ContactEntity objects that match the pagination info key.
+     */
+    @Query("SELECT * FROM contactentity WHERE pagination_info LIKE :paginationInfoKey")
+    suspend fun findByPaginationInfo(paginationInfoKey : String): List<ContactEntity>
+
+    /**
+     * Inserts a ContactEntity object into the database.
+     *
+     * @param contactEntity The ContactEntity object to be inserted.
+     */
+    @Insert
+    suspend fun insertAll(vararg contactEntity: ContactEntity)
+}

--- a/data/src/main/java/com/jperez/lydia/data/database/PaginationInfoDao.kt
+++ b/data/src/main/java/com/jperez/lydia/data/database/PaginationInfoDao.kt
@@ -1,0 +1,18 @@
+package com.jperez.lydia.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.jperez.lydia.data.model.entity.PaginationInfoEntity
+
+@Dao
+interface PaginationInfoDao {
+
+    @Query("SELECT * FROM paginationinfoentity WHERE seed LIKE :seed AND " +
+            "page = :page AND page_size = :pageSize LIMIT 1")
+    suspend fun findByInfo(seed: String, page: Int, pageSize : Int): PaginationInfoEntity?
+
+    @Insert
+    suspend fun insertAll(vararg paginationInfoEntity: PaginationInfoEntity)
+
+}

--- a/data/src/main/java/com/jperez/lydia/data/datasource/ContactLocalDataSource.kt
+++ b/data/src/main/java/com/jperez/lydia/data/datasource/ContactLocalDataSource.kt
@@ -1,0 +1,35 @@
+package com.jperez.lydia.data.datasource
+
+import com.jperez.lydia.data.model.ContactATO
+
+interface ContactLocalDataSource {
+
+    /**
+     * Retrieves a list of contacts from the database based on the provided seed, page, and page size.
+     *
+     * @param seed The seed value used to filter contacts.
+     * @param page The page number for pagination.
+     * @param pageSize The number of contacts per page.
+     * @return A list of ContactATO objects or null if no contacts are found.
+     */
+    suspend fun getRequestedContactFromDatabase(
+        seed: String,
+        page: Int,
+        pageSize: Int
+    ): List<ContactATO>?
+
+    /**
+     * Saves a list of contacts to the database.
+     *
+     * @param seed The seed value used to identify the contacts.
+     * @param page The page number for pagination.
+     * @param pageSize The number of contacts per page.
+     * @param contacts The list of ContactATO objects to be saved.
+     */
+    suspend fun saveContactsToDatabase(
+        seed: String,
+        page: Int,
+        pageSize: Int,
+        contacts: List<ContactATO>
+    )
+}

--- a/data/src/main/java/com/jperez/lydia/data/datasource/ContactLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/jperez/lydia/data/datasource/ContactLocalDataSourceImpl.kt
@@ -1,0 +1,57 @@
+package com.jperez.lydia.data.datasource
+
+import com.jperez.lydia.data.database.ContactDao
+import com.jperez.lydia.data.database.PaginationInfoDao
+import com.jperez.lydia.data.mapper.ContactAtoEntityMapper
+import com.jperez.lydia.data.model.ContactATO
+import com.jperez.lydia.data.model.entity.PaginationInfoEntity
+import org.koin.java.KoinJavaComponent.inject
+import java.util.UUID
+
+class ContactLocalDataSourceImpl : ContactLocalDataSource {
+    private val paginationInfoDao: PaginationInfoDao by inject(PaginationInfoDao::class.java)
+    private val contactDao: ContactDao by inject(ContactDao::class.java)
+    private val mapper: ContactAtoEntityMapper by inject(ContactAtoEntityMapper::class.java)
+
+    override suspend fun getRequestedContactFromDatabase(
+        seed: String,
+        page: Int,
+        pageSize: Int
+    ): List<ContactATO>? {
+        try {
+            val paginationInfoEntity = paginationInfoDao.findByInfo(seed, page, pageSize)
+            if (paginationInfoEntity == null) {
+                return null
+            } else {
+                val entities = contactDao.findByPaginationInfo(paginationInfoEntity.uid)
+                return mapper.mapEntityListToATOList(entities)
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    override suspend fun saveContactsToDatabase(
+        seed: String,
+        page: Int,
+        pageSize: Int,
+        contacts: List<ContactATO>
+    ) {
+        val paginationId = UUID.randomUUID().toString()
+        val paginationEntity = PaginationInfoEntity(
+            uid = paginationId,
+            seed = seed,
+            page = page,
+            pageSize = pageSize
+        )
+
+        paginationInfoDao.insertAll(paginationEntity)
+        contactDao.insertAll(
+            *mapper.mapATOListToEntityList(
+                contacts,
+                paginationInfoId = paginationId
+            ).toTypedArray()
+        )
+    }
+
+}

--- a/data/src/main/java/com/jperez/lydia/data/datasource/ContactRemoteDataSource.kt
+++ b/data/src/main/java/com/jperez/lydia/data/datasource/ContactRemoteDataSource.kt
@@ -2,7 +2,7 @@ package com.jperez.lydia.data.datasource
 
 import com.jperez.lydia.data.model.APIResponseATO
 
-interface ContactContactRemoteDataSource {
+interface ContactRemoteDataSource {
 
     /**
      * Get a response from the API.

--- a/data/src/main/java/com/jperez/lydia/data/datasource/ContactRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/jperez/lydia/data/datasource/ContactRemoteDataSourceImpl.kt
@@ -4,7 +4,7 @@ import com.jperez.lydia.data.api.ApiClient
 import com.jperez.lydia.data.model.APIResponseATO
 import org.koin.java.KoinJavaComponent.inject
 
-class ContactContactRemoteDataSourceImpl : ContactContactRemoteDataSource {
+class ContactRemoteDataSourceImpl : ContactRemoteDataSource {
     private val apiClient: ApiClient by inject(ApiClient::class.java)
 
     override suspend fun getContacts(seed: String, page: Int, pageSize: Int): APIResponseATO {

--- a/data/src/main/java/com/jperez/lydia/data/di/DataKoinModule.kt
+++ b/data/src/main/java/com/jperez/lydia/data/di/DataKoinModule.kt
@@ -1,20 +1,48 @@
 package com.jperez.lydia.data.di
 
+import androidx.room.Room
 import com.jperez.lydia.data.api.ApiClient
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSource
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSourceImpl
+import com.jperez.lydia.data.database.AppDatabase
+import com.jperez.lydia.data.database.ContactDao
+import com.jperez.lydia.data.database.PaginationInfoDao
+import com.jperez.lydia.data.datasource.ContactLocalDataSource
+import com.jperez.lydia.data.datasource.ContactLocalDataSourceImpl
+import com.jperez.lydia.data.datasource.ContactRemoteDataSource
+import com.jperez.lydia.data.datasource.ContactRemoteDataSourceImpl
+import com.jperez.lydia.data.mapper.ContactAtoEntityMapper
 import com.jperez.lydia.data.repository.ContactRepository
 import com.jperez.lydia.data.repository.ContactRepositoryImpl
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 var dataKoinModule = module {
     factory<ApiClient> {
         ApiClient()
     }
-    factory<ContactContactRemoteDataSource> {
-        ContactContactRemoteDataSourceImpl()
+    factory<ContactRemoteDataSource> {
+        ContactRemoteDataSourceImpl()
+    }
+    factory<ContactLocalDataSource> {
+        ContactLocalDataSourceImpl()
     }
     factory<ContactRepository> {
         ContactRepositoryImpl()
+    }
+    factory<ContactAtoEntityMapper> {
+        ContactAtoEntityMapper()
+    }
+
+    single<AppDatabase> {
+        Room.databaseBuilder(
+            androidContext(),
+            AppDatabase::class.java,
+            "lydia_db"
+        ).build()
+    }
+    single<PaginationInfoDao> {
+        get<AppDatabase>().paginationInfoDao()
+    }
+    single<ContactDao> {
+        get<AppDatabase>().contactDao()
     }
 }

--- a/data/src/main/java/com/jperez/lydia/data/mapper/ContactAtoEntityMapper.kt
+++ b/data/src/main/java/com/jperez/lydia/data/mapper/ContactAtoEntityMapper.kt
@@ -1,0 +1,156 @@
+package com.jperez.lydia.data.mapper
+
+import com.jperez.lydia.data.model.ContactATO
+import com.jperez.lydia.data.model.ContactDateATO
+import com.jperez.lydia.data.model.ContactIdATO
+import com.jperez.lydia.data.model.ContactLocationATO
+import com.jperez.lydia.data.model.ContactLocationCoordinatesATO
+import com.jperez.lydia.data.model.ContactLocationStreetATO
+import com.jperez.lydia.data.model.ContactLocationTimezoneATO
+import com.jperez.lydia.data.model.ContactLoginATO
+import com.jperez.lydia.data.model.ContactNameATO
+import com.jperez.lydia.data.model.ContactPictureATO
+import com.jperez.lydia.data.model.entity.ContactEntity
+
+class ContactAtoEntityMapper {
+
+    /**
+     * Map a list of [ContactATO] objects to a list of [ContactEntity] objects.
+     *
+     * @param atos The list of [ContactATO] objects to be mapped.
+     * @param paginationInfoId The ID of the pagination info to associate with the contacts.
+     * @return A list of [ContactEntity] objects with the mapped values.
+     */
+    fun mapATOListToEntityList(
+        atos: List<ContactATO>,
+        paginationInfoId: String
+    ): List<ContactEntity> {
+        return atos.map { ato ->
+            mapATOToEntity(ato, paginationInfoId)
+        }
+    }
+
+    /**
+     * Map a list of [ContactEntity] objects to a list of [ContactATO] objects.
+     *
+     * @param entities The list of [ContactEntity] objects to be mapped.
+     * @return A list of [ContactATO] objects with the mapped values.
+     */
+    fun mapEntityListToATOList(entities: List<ContactEntity>): List<ContactATO> {
+        return entities.map { ato ->
+            mapEntityToATO(ato)
+        }
+    }
+
+    /**
+     * Map a [ContactATO] object to a [ContactEntity] object.
+     *
+     * @param ato The [ContactATO] object to be mapped.
+     * @param paginationInfoId The ID of the pagination info to associate with the contact.
+     * @return A [ContactEntity] object with the mapped values.
+     */
+    private fun mapATOToEntity(ato: ContactATO, paginationInfoId: String): ContactEntity =
+        ContactEntity(
+            paginationInfo = paginationInfoId,
+            uid = ato.login.uuid,
+            gender = ato.gender,
+            firstName = ato.name.first,
+            lastName = ato.name.last,
+            title = ato.name.title,
+            city = ato.location.city,
+            state = ato.location.state,
+            country = ato.location.country,
+            postCode = ato.location.postCode,
+            streetName = ato.location.street.name,
+            streetNumber = ato.location.street.number,
+            age = ato.dateOfBirth.age,
+            dateOfBirth = ato.dateOfBirth.date,
+            dateOfRegistration = ato.registered.date,
+            email = ato.email,
+            phone = ato.phone,
+            cell = ato.cell,
+            largePicture = ato.picture.large,
+            mediumPicture = ato.picture.medium,
+            thumbPicture = ato.picture.thumbnail,
+            coordinatesLatitude = ato.location.coordinates.latitude,
+            coordinatesLongitude = ato.location.coordinates.longitude,
+            timeZoneOffset = ato.location.timezone.offset,
+            timeZoneDescription = ato.location.timezone.description,
+            loginUsername = ato.login.username,
+            loginPassword = ato.login.password,
+            loginSalt = ato.login.salt,
+            loginMd5 = ato.login.md5,
+            loginSha1 = ato.login.sha1,
+            loginSha256 = ato.login.sha256,
+            registrationAge = ato.registered.age,
+            contactName = ato.id.name,
+            contactValue = ato.id.value,
+            nationality = ato.nat
+        )
+
+    /**
+     * Map a [ContactEntity] object to a [ContactATO] object.
+     *
+     * @param entity The [ContactEntity] object to be mapped.
+     * @return A [ContactATO] object with the mapped values.
+     */
+    private fun mapEntityToATO(entity: ContactEntity): ContactATO {
+        return ContactATO(
+            gender = entity.gender,
+            name = ContactNameATO(
+                title = entity.title,
+                first = entity.firstName,
+                last = entity.lastName
+            ),
+            location = ContactLocationATO(
+                street = ContactLocationStreetATO(
+                    number = entity.streetNumber,
+                    name = entity.streetName
+                ),
+                city = entity.city,
+                state = entity.state,
+                country = entity.country,
+                postCode = entity.postCode,
+                coordinates = ContactLocationCoordinatesATO(
+                    latitude = entity.coordinatesLatitude,
+                    longitude = entity.coordinatesLongitude
+                ),
+                timezone = ContactLocationTimezoneATO(
+                    offset = entity.timeZoneOffset,
+                    description = entity.timeZoneDescription
+                ),
+            ),
+            email = entity.email,
+            login = ContactLoginATO(
+                uuid = entity.uid,
+                username = entity.loginUsername,
+                password = entity.loginPassword,
+                salt = entity.loginSalt,
+                md5 = entity.loginMd5,
+                sha1 = entity.loginSha1,
+                sha256 = entity.loginSha256
+            ),
+            dateOfBirth = ContactDateATO(
+                date = entity.dateOfBirth,
+                age = entity.age
+            ),
+            registered = ContactDateATO(
+                date = entity.dateOfRegistration,
+                age = entity.registrationAge
+            ),
+            phone = entity.phone,
+            cell = entity.cell,
+            id = ContactIdATO(
+                name = entity.contactName,
+                value = entity.contactValue
+            ),
+            picture = ContactPictureATO(
+                large = entity.largePicture,
+                medium = entity.mediumPicture,
+                thumbnail = entity.thumbPicture
+            ),
+            nat = entity.nationality
+
+        )
+    }
+}

--- a/data/src/main/java/com/jperez/lydia/data/model/entity/ContactEntity.kt
+++ b/data/src/main/java/com/jperez/lydia/data/model/entity/ContactEntity.kt
@@ -1,0 +1,55 @@
+package com.jperez.lydia.data.model.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = PaginationInfoEntity::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("pagination_info"),
+            onUpdate = ForeignKey.CASCADE,
+            onDelete = ForeignKey.CASCADE
+        )]
+)
+data class ContactEntity(
+    @PrimaryKey @ColumnInfo(name = "id") val uid: String,
+    @ColumnInfo(name = "pagination_info") val paginationInfo: String,
+    @ColumnInfo(name = "first_name") val firstName: String,
+    @ColumnInfo(name = "last_name") val lastName: String,
+    @ColumnInfo(name = "gender") val gender: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "city") val city: String,
+    @ColumnInfo(name = "state") val state: String,
+    @ColumnInfo(name = "country") val country: String,
+    @ColumnInfo(name = "post_code") val postCode: String,
+    @ColumnInfo(name = "street_name") val streetName: String,
+    @ColumnInfo(name = "street_number") val streetNumber: Int,
+    @ColumnInfo(name = "age") val age : Int,
+    @ColumnInfo(name = "registration_age") val registrationAge : Int,
+    @ColumnInfo(name = "date_of_birth") val dateOfBirth: String,
+    @ColumnInfo(name = "date_of_registration") val dateOfRegistration: String,
+    @ColumnInfo(name = "email") val email: String,
+    @ColumnInfo(name = "phone") val phone: String,
+    @ColumnInfo(name = "cell") val cell: String,
+    @ColumnInfo(name = "largePicture") val largePicture: String,
+    @ColumnInfo(name = "mediumPicture") val mediumPicture: String,
+    @ColumnInfo(name = "thumbPicture") val thumbPicture: String,
+    @ColumnInfo(name = "coordinates_latitude") val coordinatesLatitude: String,
+    @ColumnInfo(name = "coordinates_longitude") val coordinatesLongitude: String,
+    @ColumnInfo(name = "timezone_offset") val timeZoneOffset: String,
+    @ColumnInfo(name = "timezone_description") val timeZoneDescription: String,
+    @ColumnInfo(name = "login_username") val loginUsername: String,
+    @ColumnInfo(name = "login_password") val loginPassword: String,
+    @ColumnInfo(name = "login_salt") val loginSalt: String,
+    @ColumnInfo(name = "login_md5") val loginMd5: String,
+    @ColumnInfo(name = "login_sha1") val loginSha1: String,
+    @ColumnInfo(name = "login_sha256") val loginSha256: String,
+    @ColumnInfo(name = "contact_name") val contactName: String,
+    @ColumnInfo(name = "contact_value") val contactValue: String?,
+    @ColumnInfo(name = "nationality") val nationality: String,
+
+    )

--- a/data/src/main/java/com/jperez/lydia/data/model/entity/PaginationInfoEntity.kt
+++ b/data/src/main/java/com/jperez/lydia/data/model/entity/PaginationInfoEntity.kt
@@ -1,0 +1,13 @@
+package com.jperez.lydia.data.model.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class PaginationInfoEntity(
+    @PrimaryKey @ColumnInfo(name = "id") val uid: String,
+    @ColumnInfo(name = "seed") val seed: String,
+    @ColumnInfo(name = "page") val page: Int,
+    @ColumnInfo(name = "page_size") val pageSize: Int,
+)

--- a/data/src/main/java/com/jperez/lydia/data/paging/ContactPagingSource.kt
+++ b/data/src/main/java/com/jperez/lydia/data/paging/ContactPagingSource.kt
@@ -2,7 +2,8 @@ package com.jperez.lydia.data.paging
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSource
+import com.jperez.lydia.data.datasource.ContactLocalDataSource
+import com.jperez.lydia.data.datasource.ContactRemoteDataSource
 import com.jperez.lydia.data.model.ContactATO
 import org.koin.java.KoinJavaComponent.inject
 
@@ -13,22 +14,50 @@ import org.koin.java.KoinJavaComponent.inject
  */
 
 class ContactPagingSource(private val seed: String): PagingSource<Int, ContactATO>() {
-    private val remoteDataSource: ContactContactRemoteDataSource by inject(
-        ContactContactRemoteDataSource::class.java)
+    private val remoteDataSource: ContactRemoteDataSource by inject(
+        ContactRemoteDataSource::class.java)
+    private val localDataSource: ContactLocalDataSource by inject(
+        ContactLocalDataSource::class.java)
 
+    /**
+     * Loads a page of contacts from the remote data source or local cache.
+     * If the contacts are not available in the local cache,
+     * it fetches them from the remote data source and saves them to the local cache.
+     *
+     */
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ContactATO> {
         return try {
             val currentPage = params.key ?: 1
-            val response = remoteDataSource.getContacts(
+
+            val cachedContacts = localDataSource.getRequestedContactFromDatabase(
                 seed = seed,
                 page = currentPage,
                 pageSize = params.loadSize
             )
-            LoadResult.Page(
-                data = response.results,
-                prevKey = if (currentPage == 1) null else currentPage - 1,
-                nextKey = if (response.results.isEmpty()) null else response.info.page + 1
-            )
+            if(cachedContacts != null){
+                LoadResult.Page(
+                    data = cachedContacts,
+                    prevKey = if (currentPage == 1) null else currentPage - 1,
+                    nextKey = if (cachedContacts.isEmpty()) null else currentPage + 1
+                )
+            } else {
+                val response = remoteDataSource.getContacts(
+                    seed = seed,
+                    page = currentPage,
+                    pageSize = params.loadSize
+                )
+                localDataSource.saveContactsToDatabase(
+                    seed = seed,
+                    page = currentPage,
+                    pageSize = params.loadSize,
+                    contacts = response.results
+                )
+                LoadResult.Page(
+                    data = response.results,
+                    prevKey = if (currentPage == 1) null else currentPage - 1,
+                    nextKey = if (response.results.isEmpty()) null else response.info.page + 1
+                )
+            }
         } catch (exception: Exception) {
             return LoadResult.Error(exception)
         }
@@ -37,5 +66,4 @@ class ContactPagingSource(private val seed: String): PagingSource<Int, ContactAT
     override fun getRefreshKey(state: PagingState<Int, ContactATO>): Int? {
         return state.anchorPosition
     }
-
 }

--- a/data/src/test/java/com/jperez/lydia/data/ContactAtoEntityMapperTest.kt
+++ b/data/src/test/java/com/jperez/lydia/data/ContactAtoEntityMapperTest.kt
@@ -1,0 +1,31 @@
+package com.jperez.lydia.data
+
+import com.jperez.lydia.data.mapper.ContactAtoEntityMapper
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.koin.test.KoinTest
+
+/**
+ * Unit tests for the ContactAtoEntityMapper class.
+ */
+class ContactAtoEntityMapperTest : KoinTest {
+    private val mapper: ContactAtoEntityMapper = ContactAtoEntityMapper()
+
+    @Test
+    fun `map ATO to Entity`() = runTest {
+        val result = mapper.mapATOListToEntityList(
+            listOf(DataMockConstants.contactATO),
+            DataMockConstants.apiResponseInfoATO.seed
+        )
+        assertEquals(DataMockConstants.contactEntity, result.first())
+    }
+
+    @Test
+    fun `map Entity to ATO`() = runTest {
+        val result = mapper.mapEntityListToATOList(
+            listOf(DataMockConstants.contactEntity),
+        )
+        assertEquals(DataMockConstants.contactATO, result.first())
+    }
+}

--- a/data/src/test/java/com/jperez/lydia/data/ContactLocalDataSourceTest.kt
+++ b/data/src/test/java/com/jperez/lydia/data/ContactLocalDataSourceTest.kt
@@ -1,0 +1,114 @@
+package com.jperez.lydia.data
+
+import com.jperez.lydia.data.database.ContactDao
+import com.jperez.lydia.data.database.PaginationInfoDao
+import com.jperez.lydia.data.datasource.ContactLocalDataSource
+import com.jperez.lydia.data.datasource.ContactLocalDataSourceImpl
+import com.jperez.lydia.data.mapper.ContactAtoEntityMapper
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.context.GlobalContext.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+
+/**
+ * Unit tests for the ContactLocalDataSource class.
+ */
+class ContactLocalDataSourceTest : KoinTest {
+    private lateinit var mockContactDao: ContactDao
+    private lateinit var mockPaginationInfoDao: PaginationInfoDao
+    private lateinit var mockContactAtoEntityMapper: ContactAtoEntityMapper
+    private lateinit var localDataSource: ContactLocalDataSource
+
+    @Before
+    fun setUp() {
+        mockContactDao = mockk(relaxed = true)
+        mockPaginationInfoDao = mockk(relaxed = true)
+        mockContactAtoEntityMapper = mockk(relaxed = true)
+        localDataSource = ContactLocalDataSourceImpl()
+
+        startKoin {
+            modules(
+                module {
+                    single<ContactDao> { mockContactDao }
+                    single<PaginationInfoDao> { mockPaginationInfoDao }
+                    single<ContactAtoEntityMapper> { mockContactAtoEntityMapper }
+                })
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `paginationInfo findByInfo return null so result is null`() = runTest {
+        coEvery { mockPaginationInfoDao.findByInfo(seed = "default",  page= 1, pageSize = 10) } returns null
+
+        val result = localDataSource.getRequestedContactFromDatabase("default",  page= 1, pageSize = 10)
+
+        assertNull(result)
+        coVerify(exactly = 0) {
+            mockContactDao.findByPaginationInfo(
+                paginationInfoKey = any()
+            )
+        }
+    }
+
+    @Test
+    fun `paginationInfo is save so get function return list of contact`() = runTest {
+        coEvery { mockPaginationInfoDao.findByInfo(seed = "default",  page= 1, pageSize = 10) } returns DataMockConstants.paginationInfoEntity
+        coEvery { mockContactDao.findByPaginationInfo("pagination-id") } returns listOf(DataMockConstants.contactEntity)
+        coEvery { mockContactAtoEntityMapper.mapEntityListToATOList(listOf(DataMockConstants.contactEntity)) } returns listOf(DataMockConstants.contactATO)
+
+        val result = localDataSource.getRequestedContactFromDatabase("default",  page= 1, pageSize = 10)
+        assertEquals(DataMockConstants.contactATO, result?.first())
+    }
+
+    @Test
+    fun `paginationInfo findByInfo throw exception return null`() = runTest {
+        coEvery { mockPaginationInfoDao.findByInfo(seed = "default",  page= 1, pageSize = 10) } throws Exception("Database error")
+
+        val result = localDataSource.getRequestedContactFromDatabase("default",  page= 1, pageSize = 10)
+
+        assertNull(result)
+        coVerify(exactly = 0) {
+            mockContactDao.findByPaginationInfo(
+                paginationInfoKey = any()
+            )
+        }
+    }
+
+    @Test
+    fun `paginationInfo findByPaginationInfo throw exception return null`() = runTest {
+        coEvery { mockPaginationInfoDao.findByInfo(seed = "default",  page= 1, pageSize = 10) } returns DataMockConstants.paginationInfoEntity
+        coEvery { mockContactDao.findByPaginationInfo("pagination-id") } throws Exception("Database error")
+        coEvery { mockContactAtoEntityMapper.mapEntityListToATOList(listOf(DataMockConstants.contactEntity)) } returns listOf(DataMockConstants.contactATO)
+
+        val result = localDataSource.getRequestedContactFromDatabase("default",  page= 1, pageSize = 10)
+        assertNull(result)
+    }
+
+    @Test
+    fun `paginationInfo save call daos`() = runTest {
+        coEvery { mockPaginationInfoDao.insertAll(any()) } answers {}
+        coEvery { mockContactAtoEntityMapper.mapATOListToEntityList(listOf(DataMockConstants.contactATO), paginationInfoId = any()) } returns listOf(DataMockConstants.contactEntity)
+        coEvery { mockContactDao.insertAll(any()) } answers {}
+         localDataSource.saveContactsToDatabase("default",  page= 1, pageSize = 10, contacts = listOf(DataMockConstants.contactATO))
+
+        coVerify {
+            mockPaginationInfoDao.insertAll(any())
+        }
+        coVerify {
+            mockContactDao.insertAll(any())
+        }
+    }
+}

--- a/data/src/test/java/com/jperez/lydia/data/ContactRemoteDataSourceTest.kt
+++ b/data/src/test/java/com/jperez/lydia/data/ContactRemoteDataSourceTest.kt
@@ -1,8 +1,8 @@
 package com.jperez.lydia.data
 
 import com.jperez.lydia.data.api.ApiClient
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSource
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSourceImpl
+import com.jperez.lydia.data.datasource.ContactRemoteDataSource
+import com.jperez.lydia.data.datasource.ContactRemoteDataSourceImpl
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -17,16 +17,16 @@ import org.koin.test.KoinTest
 
 
 /**
- * Unit tests for the ContactContactRemoteDataSource class.
+ * Unit tests for the ContactRemoteDataSource class.
  */
-class ContactContactRemoteDataSourceTest : KoinTest {
+class ContactRemoteDataSourceTest : KoinTest {
     private lateinit var mockApiClient: ApiClient
-    private lateinit var remoteDataSource: ContactContactRemoteDataSource
+    private lateinit var remoteDataSource: ContactRemoteDataSource
 
     @Before
     fun setUp() {
         mockApiClient = mockk(relaxed = true)
-        remoteDataSource = ContactContactRemoteDataSourceImpl()
+        remoteDataSource = ContactRemoteDataSourceImpl()
     }
 
     @After

--- a/data/src/test/java/com/jperez/lydia/data/ContactRepositoryTest.kt
+++ b/data/src/test/java/com/jperez/lydia/data/ContactRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.jperez.lydia.data
 
 import androidx.paging.testing.asSnapshot
-import com.jperez.lydia.data.datasource.ContactContactRemoteDataSource
+import com.jperez.lydia.data.datasource.ContactRemoteDataSource
 import com.jperez.lydia.data.repository.ContactRepository
 import com.jperez.lydia.data.repository.ContactRepositoryImpl
 import io.mockk.coEvery
@@ -21,12 +21,12 @@ import org.koin.test.KoinTest
  * Unit tests for the ContactRepository class.
  */
 class ContactRepositoryTest : KoinTest {
-    private lateinit var mockContactContactRemoteDataSource: ContactContactRemoteDataSource
+    private lateinit var mockContactRemoteDataSource: ContactRemoteDataSource
     private lateinit var repository: ContactRepository
 
     @Before
     fun setUp() {
-        mockContactContactRemoteDataSource = mockk(relaxed = true)
+        mockContactRemoteDataSource = mockk(relaxed = true)
         repository = ContactRepositoryImpl()
     }
 
@@ -40,10 +40,10 @@ class ContactRepositoryTest : KoinTest {
         startKoin {
             modules(
                 module {
-                    single<ContactContactRemoteDataSource> { mockContactContactRemoteDataSource }
+                    single<ContactRemoteDataSource> { mockContactRemoteDataSource }
                 })
         }
-        coEvery { mockContactContactRemoteDataSource.getContacts("default", page= 1, pageSize = 20) } returns DataMockConstants.apiResponseATO
+        coEvery { mockContactRemoteDataSource.getContacts("default", page= 1, pageSize = 20) } returns DataMockConstants.apiResponseATO
 
         val result = repository.getContacts("default")
 

--- a/data/src/test/java/com/jperez/lydia/data/DataMockConstants.kt
+++ b/data/src/test/java/com/jperez/lydia/data/DataMockConstants.kt
@@ -12,10 +12,12 @@ import com.jperez.lydia.data.model.ContactLocationTimezoneATO
 import com.jperez.lydia.data.model.ContactLoginATO
 import com.jperez.lydia.data.model.ContactNameATO
 import com.jperez.lydia.data.model.ContactPictureATO
+import com.jperez.lydia.data.model.entity.ContactEntity
+import com.jperez.lydia.data.model.entity.PaginationInfoEntity
 
 class DataMockConstants {
     companion object {
-        private val apiResponseInfoATO = APIResponseInfoATO(
+        val apiResponseInfoATO = APIResponseInfoATO(
             seed = "seed",
             page = 1,
             results = 0,
@@ -79,9 +81,55 @@ class DataMockConstants {
             nat = "FR"
         )
 
+
+        val contactEntity = ContactEntity(
+            gender = "male",
+            title = "Mr",
+            firstName = "Marin",
+            lastName = "Meunier",
+            streetNumber = 815,
+            streetName = "Rue de la Gare",
+            city = "Limoges",
+            state = "Puy-de-Dôme",
+            country = "France",
+            postCode = "53806",
+            coordinatesLatitude = "-3.9384",
+            coordinatesLongitude = "-81.7879",
+            timeZoneOffset = "+9:00",
+            timeZoneDescription = "Tokyo, Seoul, Osaka, Sapporo, Yakutsk",
+            email = "marin.meunier@example.com",
+            uid = "9ae1a7c7-77df-48cd-a0bb-e1b0c3527058",
+            loginUsername = "sadpeacock902",
+            loginPassword = "1223",
+            loginSalt = "EB17IVYy",
+            loginMd5 = "5acba14df336f8b6e542ac5e482c1b3e",
+            loginSha1 = "53683ae46a7cea2d6c308d9ac5e47ebf36599898",
+            loginSha256 = "c5511590d3dca7f324872c0d9e959bdd073c65989c46a88db5e9f6c70a63932f",
+            dateOfBirth = "1949-06-16T15:54:25.494Z",
+            age = 76,
+            dateOfRegistration = "2015-01-31T06:11:25.576Z",
+            registrationAge = 10,
+            phone = "04-23-14-03-57",
+            cell = "06-46-24-26-68",
+            contactName = "INSEE",
+            contactValue = "1NNaN22049525 97",
+            largePicture = "https://randomuser.me/api/portraits/men/6.jpg",
+            mediumPicture = "https://randomuser.me/api/portraits/med/men/6.jpg",
+            thumbPicture = "https://randomuser.me/api/portraits/thumb/men/6.jpg",
+            nationality = "FR",
+            paginationInfo = "seed"
+        )
+
         val apiResponseATO = APIResponseATO(
             results = listOf(contactATO),
             info = apiResponseInfoATO
+        )
+
+        val paginationInfoEntity = PaginationInfoEntity(
+            uid = "pagination-id",
+            seed = "default",
+            page = 1,
+            pageSize = 10
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,9 @@ appcompat = "1.7.1"
 material = "1.12.0"
 mockkVersion = "1.14.5"
 pagingVersion = "3.3.6"
+roomCompiler = "2.7.2"
+roomVersion = "2.7.2"
+kspVersion = "2.2.0-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -52,6 +55,9 @@ mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockkVe
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "pagingVersion" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "pagingVersion" }
 androidx-paging-testing = { group = "androidx.paging", name = "paging-testing", version.ref = "pagingVersion" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "roomVersion" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomVersion" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -59,4 +65,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinx" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
+
 


### PR DESCRIPTION
Ajout de la librairie Room pour créer des bases de données et sauvegarder les données depuis l'API.

Explications des choix : 

- Pourquoi Room et choix de la structure de base de données
Pour stocker une large quantité de données sur le téléphone, le mieux rester une base de données, et la librairie Room fonctionne très bien. La base de données contient 2 tables, une contenant les informations de la pagination avec la seed, la page et la taille de la page, ce qui nous permet d'avoir un id. Une autre table contacts aura toutes les infos des contacts correspondant à cette pagination.

- Emplacement de la logique
J'ai placé la logique dans la ContactPagingSource, d'abord on regarde si il existe dans la base de donnée une pagination sauvegardée avec les bons paramètres, si c'est le cas on aura notre liste de contacts, si non, on appelle l'API et on sauvegarde les données dans la bdd. J'ai vu l'existence de la classe RemoteMediator (notamment avec ce [tuto](https://developer.android.com/topic/libraries/architecture/paging/v3-network-db) , mais je connaissais pas cette classe et je me suis dis mon idée s'en rapproche tout en restant assez simple et efficace.